### PR TITLE
Relaxed requirement for the engine: it still needs ReducerCreator, bu…

### DIFF
--- a/.idea/dictionaries/PierreJean.xml
+++ b/.idea/dictionaries/PierreJean.xml
@@ -2,6 +2,7 @@
   <dictionary name="PierreJean">
     <words>
       <w>chiswick</w>
+      <w>horrocks</w>
     </words>
   </dictionary>
 </component>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ They are:
 - `State`. The set of data that represents the state of the view.
 - `Reducer`. A piece of code that contains both data (equivalent to a Redux action) and process (Redux's reducer). When applied to a 
 `State` this applies its data on to the state and produces a new `State`
-- `ReducerCreator`. A piece of code that processes a specific type of UI events and creates `Reducer`s for this type of event.
+- `TriggeredReducerCreator`. A piece of code that processes a specific type of UI events and creates `Reducer`s for this type of event.
+  A simpler version `ReducerCreator` is not specifically triggered by an event.
 - `Engine`: the code that collects the `Reducer`s emitted by `ReducerCreator`s and applies then to the current `State`.
 It also calculate the `Model` from the `state` and emits it.
 
@@ -43,9 +44,10 @@ of the screen.
 `State` is the only source of data in `Model`, so it supports transient properties as well.
 
 ### ReducerCreator
-An `ReducerCreator` can be triggered by an `Event` and emits a series of `Reducer`s. It is named `ReducerCreator` because its semantics 
+A `ReducerCreator` emits a series of `Reducer`s. It is named `ReducerCreator` because its semantics
 are close to Redux's ActionCreator. It emits more than Actions however: Horrocks' `Reducer`s.
- 
+A `TriggeredReducerCreator` is a `ReducerCreator` that can be triggered by an `Event`.
+
 ### Reducer
 A `Reducer` is close semantically to Redux's Reducer. The major difference is that the main (only) method of a Redux reducer is a pure 
 function that take 2 parameters: the action data and a state to produce a new state. Horrocks' `Reducer` already contains the data to 
@@ -59,7 +61,7 @@ There should be one instance of an engine (noted above as the system) per screen
 
 ## Other Abstractions
 ### Help with Feature creation
-`ReducerCreator`s have some boiler-plate code. 4 classes are designed to remove as much as possible:
+`TriggeredReducerCreator`s have some boiler-plate code. 4 classes are designed to remove of it as much as possible:
 - `SingleReducerCreator` and `Interaction`
 - `MultipleReducerCreator` and `AsyncInteraction`
 
@@ -95,10 +97,10 @@ a `TransientCleaner` onto the state. The engine gets its cleaner from its `Confi
 
 
 ### Validation
-In certain cases, a `ReducerCreator` need to validate `Event`s against the current `State` of the app and then emit the relevant `Reducer`.
+In certain cases, a `TriggeredReducerCreator` need to validate `Event`s against the current `State` of the app and then emit the relevant `Reducer`.
 `StateProvider` is designed to be used in this scenario. Pass one in the constructor of the `ActionCreator` and Bob's your uncle. The 
 only implementation of `StateProvider` That makes sense delegates to the `Storage` use in the screen. 
-The `ReducerCreator` uses this state to decide what `Reducer`(s) to emit. Note that the state used then may not be the same as the one 
+The `TriggeredReducerCreator` uses this state to decide what `Reducer`(s) to emit. Note that the state used then may not be the same as the one
 handed to the `Reducer`(s), as some other `Reducer` of a different origin may have be executed in the meantime.
   
 
@@ -112,7 +114,7 @@ allprojects {
   }
 }
 ```
-Add the dependency
+Add the dependency:
 ```groovy
 dependencies {
   compile 'com.github.pijpijpij.horrocks:horrocks:0.4.1'
@@ -132,7 +134,7 @@ In an MVP architecture, assuming that attaching the view to its presenter is don
 create that subscription. In the sample application, it is in the implementations of `BasePresenter.takeView()` that 
 `Engine.runWith(Configuration)` is subscribed to.
 
-# Building and Releasing the libraries
+# Building and Releasing the library
 
 ## Automated build status
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/presenter/FeaturedPresenter.java
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/presenter/FeaturedPresenter.java
@@ -28,7 +28,7 @@ import com.pij.horrocks.Configuration;
 import com.pij.horrocks.Engine;
 import com.pij.horrocks.MemoryStorage;
 import com.pij.horrocks.MultipleReducerCreator;
-import com.pij.horrocks.ReducerCreator;
+import com.pij.horrocks.TriggeredReducerCreator;
 import com.pij.horrocks.View;
 import com.pij.utils.Logger;
 
@@ -58,8 +58,8 @@ public final class FeaturedPresenter implements Presenter {
     private final CompositeDisposable subscription = new CompositeDisposable();
     private final Engine<AddEditTaskModel, AddEditTaskModel> engine;
     private final Configuration<AddEditTaskModel, AddEditTaskModel> engineConfiguration;
-    private final ReducerCreator<Task, AddEditTaskModel> saveTask;
-    private final ReducerCreator<String, AddEditTaskModel> loadTask;
+    private final TriggeredReducerCreator<Task, AddEditTaskModel> saveTask;
+    private final TriggeredReducerCreator<String, AddEditTaskModel> loadTask;
 
     private String taskId;
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/presenter/FeaturedPresenter.java
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/presenter/FeaturedPresenter.java
@@ -25,7 +25,7 @@ import com.pij.horrocks.Configuration;
 import com.pij.horrocks.Engine;
 import com.pij.horrocks.MemoryStorage;
 import com.pij.horrocks.MultipleReducerCreator;
-import com.pij.horrocks.ReducerCreator;
+import com.pij.horrocks.TriggeredReducerCreator;
 import com.pij.horrocks.View;
 import com.pij.utils.Logger;
 
@@ -54,7 +54,7 @@ public final class FeaturedPresenter implements Presenter {
     private final Logger logger;
     private final CompositeDisposable subscription = new CompositeDisposable();
     private final Engine<StatisticsModel, StatisticsModel> engine;
-    private final ReducerCreator<Object, StatisticsModel> loadStatistics;
+    private final TriggeredReducerCreator<Object, StatisticsModel> loadStatistics;
     private final Configuration<StatisticsModel, StatisticsModel> engineConfiguration;
 
     /**

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/presenter/FeaturedPresenter.java
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/presenter/FeaturedPresenter.java
@@ -27,8 +27,8 @@ import com.pij.horrocks.Configuration;
 import com.pij.horrocks.Engine;
 import com.pij.horrocks.MemoryStorage;
 import com.pij.horrocks.MultipleReducerCreator;
-import com.pij.horrocks.ReducerCreator;
 import com.pij.horrocks.SingleReducerCreator;
+import com.pij.horrocks.TriggeredReducerCreator;
 import com.pij.horrocks.View;
 import com.pij.utils.Logger;
 
@@ -56,11 +56,11 @@ public final class FeaturedPresenter implements Presenter {
     private final CompositeDisposable subscription = new CompositeDisposable();
     private final Engine<TaskDetailModel, TaskDetailModel> engine;
     private final Configuration<TaskDetailModel, TaskDetailModel> engineConfiguration;
-    private final ReducerCreator<String, TaskDetailModel> loadTask;
-    private final ReducerCreator<String, TaskDetailModel> editTask;
-    private final ReducerCreator<String, TaskDetailModel> deleteTask;
-    private final ReducerCreator<String, TaskDetailModel> completeTask;
-    private final ReducerCreator<String, TaskDetailModel> activateTask;
+    private final TriggeredReducerCreator<String, TaskDetailModel> loadTask;
+    private final TriggeredReducerCreator<String, TaskDetailModel> editTask;
+    private final TriggeredReducerCreator<String, TaskDetailModel> deleteTask;
+    private final TriggeredReducerCreator<String, TaskDetailModel> completeTask;
+    private final TriggeredReducerCreator<String, TaskDetailModel> activateTask;
     @NonNull
     private String mTaskId;
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/presenter/FeaturedPresenter.java
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/presenter/FeaturedPresenter.java
@@ -28,8 +28,8 @@ import com.pij.horrocks.Configuration;
 import com.pij.horrocks.Engine;
 import com.pij.horrocks.MemoryStorage;
 import com.pij.horrocks.MultipleReducerCreator;
-import com.pij.horrocks.ReducerCreator;
 import com.pij.horrocks.SingleReducerCreator;
+import com.pij.horrocks.TriggeredReducerCreator;
 import com.pij.horrocks.View;
 import com.pij.utils.Logger;
 
@@ -57,13 +57,13 @@ public final class FeaturedPresenter implements Presenter {
     private final Logger logger;
     private final CompositeDisposable subscription = new CompositeDisposable();
     private final Engine<ViewState, TasksModel> engine;
-    private final ReducerCreator<Object, ViewState> indicateTaskSaved;
-    private final ReducerCreator<Object, ViewState> showAddTask;
-    private final ReducerCreator<Task, ViewState> openTaskDetails;
-    private final ReducerCreator<Object, ViewState> clearCompletedTasks;
-    private final ReducerCreator<Task, ViewState> activateTask;
-    private final ReducerCreator<Task, ViewState> completeTask;
-    private final ReducerCreator<FilterType, ViewState> loadTasks;
+    private final TriggeredReducerCreator<Object, ViewState> indicateTaskSaved;
+    private final TriggeredReducerCreator<Object, ViewState> showAddTask;
+    private final TriggeredReducerCreator<Task, ViewState> openTaskDetails;
+    private final TriggeredReducerCreator<Object, ViewState> clearCompletedTasks;
+    private final TriggeredReducerCreator<Task, ViewState> activateTask;
+    private final TriggeredReducerCreator<Task, ViewState> completeTask;
+    private final TriggeredReducerCreator<FilterType, ViewState> loadTasks;
     private final Configuration<ViewState, TasksModel> engineConfiguration;
 
     /**

--- a/library/src/main/java/com/pij/horrocks/Configuration.java
+++ b/library/src/main/java/com/pij/horrocks/Configuration.java
@@ -40,7 +40,7 @@ public abstract class Configuration<S, M> {
 
     public abstract Logger logger();
 
-    abstract Collection<ReducerCreator<?, S>> creators();
+    abstract Collection<ReducerCreator<S>> creators();
 
     abstract StateConverter<S, M> stateToModel();
 
@@ -83,7 +83,7 @@ public abstract class Configuration<S, M> {
 
         public abstract Builder<S, M> logger(Logger logger);
 
-        public abstract Builder<S, M> creators(Collection<ReducerCreator<?, S>> creators);
+        public abstract Builder<S, M> creators(Collection<ReducerCreator<S>> creators);
 
         public abstract Builder<S, M> stateToModel(StateConverter<S, M> stateToModel);
 

--- a/library/src/main/java/com/pij/horrocks/DefaultEngine.java
+++ b/library/src/main/java/com/pij/horrocks/DefaultEngine.java
@@ -39,7 +39,7 @@ public final class DefaultEngine<S, M> implements Engine<S, M> {
     @Override
     public Observable<M> runWith(Configuration<S, M> configuration) {
         Storage<S> storage = configuration.store();
-        Collection<ReducerCreator<?, S>> reducerCreators = configuration.creators();
+        Collection<ReducerCreator<S>> reducerCreators = configuration.creators();
         TransientCleaner<S> transientCleaner = configuration.transientResetter();
         StateEquality<S> stateFilter = configuration.stateFilter();
         StateConverter<S, M> stateConverter = configuration.stateToModel();

--- a/library/src/main/java/com/pij/horrocks/MultipleReducerCreator.java
+++ b/library/src/main/java/com/pij/horrocks/MultipleReducerCreator.java
@@ -28,7 +28,7 @@ import io.reactivex.subjects.Subject;
  * @author PierreJean
  */
 
-public final class MultipleReducerCreator<E, S> implements ReducerCreator<E, S> {
+public final class MultipleReducerCreator<E, S> implements TriggeredReducerCreator<E, S> {
     private final Subject<E> event = PublishSubject.create();
     private final AsyncInteraction<E, S> interaction;
     private final Logger logger;

--- a/library/src/main/java/com/pij/horrocks/SingleReducerCreator.java
+++ b/library/src/main/java/com/pij/horrocks/SingleReducerCreator.java
@@ -28,7 +28,7 @@ import io.reactivex.subjects.Subject;
  * @author PierreJean
  */
 
-public final class SingleReducerCreator<E, S> implements ReducerCreator<E, S> {
+public final class SingleReducerCreator<E, S> implements TriggeredReducerCreator<E, S> {
     private final Subject<E> event = PublishSubject.create();
     private final Interaction<E, S> interaction;
     private final Logger logger;

--- a/library/src/main/java/com/pij/horrocks/TriggeredReducerCreator.java
+++ b/library/src/main/java/com/pij/horrocks/TriggeredReducerCreator.java
@@ -16,16 +16,13 @@ package com.pij.horrocks;
 
 import android.support.annotation.NonNull;
 
-import io.reactivex.Observable;
-
 /**
  * <p>Created on 16/11/2017.</p>
  *
  * @author PierreJean
  */
-public interface ReducerCreator<S> {
+public interface TriggeredReducerCreator<E, S> extends ReducerCreator<S> {
 
-    @NonNull
-    Observable<Reducer<S>> reducers();
+    void trigger(@NonNull E event);
 
 }


### PR DESCRIPTION
…t it is a different one: it has been renamed ReducerCreator to TriggeredReducerCreator. The new ReducerCreator does not include any notion of event.